### PR TITLE
Enhance Markdown Rendering to Open Links in New Tabs

### DIFF
--- a/frontend/src/components/AlertBar.tsx
+++ b/frontend/src/components/AlertBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { IconSelector } from "./IconSelector";
-import { parseMarkdownToHTML } from "../utils/parseMarkdownToHTML";
+import { parseMarkdownToHTMLWithLinksInNewTab } from "../utils/parseMarkdownToHTML";
 
 export const AlertBar = ({
   heading,
@@ -57,7 +57,7 @@ export const AlertBar = ({
             <div
               className="usa-alert__text"
               dangerouslySetInnerHTML={{
-                __html: parseMarkdownToHTML(copy),
+                __html: parseMarkdownToHTMLWithLinksInNewTab(copy),
               }}
             />
           )}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -57,7 +57,7 @@ export const Layout = (props: LayoutProps) => {
       )}
       {process.env.REACT_APP_FEATURE_BETA === "true" && (
           <AlertBar
-              copy="My Career NJ is in beta. You can send feedback and comments to us through our [contact form](https://docs.google.com/forms/d/e/1FAIpQLScAP50OMhuAgb9Q44TMefw7y5p4dGoE_czQuwGq2Z9mKmVvVQ/viewform)."
+              copy={`${process.env.REACT_APP_SITE_NAME} is in beta. You can send feedback and comments to us through our [contact form](https://docs.google.com/forms/d/e/1FAIpQLScAP50OMhuAgb9Q44TMefw7y5p4dGoE_czQuwGq2Z9mKmVvVQ/viewform).`}
               type="info"
               className="beta-alert"
           />

--- a/frontend/src/utils/parseMarkdownToHTML.ts
+++ b/frontend/src/utils/parseMarkdownToHTML.ts
@@ -5,3 +5,36 @@ const mdParser = new MarkdownIt(/* Markdown-it options */);
 export const parseMarkdownToHTML = (markdown: string): string => {
   return mdParser.render(markdown);
 };
+
+// New function that modifies link behavior to open in a new tab, fixed for TypeScript
+export const parseMarkdownToHTMLWithLinksInNewTab = (markdown: string): string => {
+  // Temporarily modify the renderer for link_open to handle target and rel attributes
+  const originalLinkOpen = mdParser.renderer.rules.link_open || ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
+
+  mdParser.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    // Adding target="_blank" and rel="noopener noreferrer" to links
+    const aIndex = tokens[idx].attrIndex('target');
+    if (aIndex < 0) {
+      tokens[idx].attrPush(['target', '_blank']); // add new attribute
+    } else {
+      tokens[idx].attrs![aIndex][1] = '_blank'; // replace existing attribute
+    }
+
+    const relIndex = tokens[idx].attrIndex('rel');
+    if (relIndex < 0) {
+      tokens[idx].attrPush(['rel', 'noopener noreferrer']); // add new attribute
+    } else {
+      tokens[idx].attrs![relIndex][1] = 'noopener noreferrer'; // replace existing attribute
+    }
+
+    return originalLinkOpen(tokens, idx, options, env, self);
+  };
+
+  // Render the markdown with modified link behavior
+  const html = mdParser.render(markdown);
+
+  // Reset to original link_open renderer to avoid side effects
+  mdParser.renderer.rules.link_open = originalLinkOpen;
+
+  return html;
+};


### PR DESCRIPTION
Our application utilizes Markdown for content creation and presentation. Users have expressed a need for links within markdown content to open in new tabs to improve usability and retain the application context. Previously, links in markdown content opened in the same tab, potentially disrupting the user's workflow and navigation.
Objective:

To implement a solution that allows links within markdown-rendered content to open in new tabs by default, thereby enhancing the user experience by providing non-disruptive navigation. Additionally, address TypeScript related issues encountered during implementation to ensure type safety and maintainability.
Changes:

    Enhanced Markdown Link Rendering:
        Introduced parseMarkdownToHTMLWithLinksInNewTab function in src/utils/parseMarkdownToHtml.ts. This function extends the MarkdownIt instance to modify link behavior, ensuring links open in new tabs.
        Ensured the new function temporarily alters the link rendering behavior to avoid side effects on the global MarkdownIt instance used elsewhere in the application.

    TypeScript Adjustments:
        Addressed TypeScript errors related to the use of non-existent clone method on MarkdownIt instance and incorrect typings for token parameters and renderer methods.
        Utilized proper TypeScript typings and workarounds to maintain type safety and clarity in the codebase.

    Backward Compatibility:
        Maintained the original parseMarkdownToHTML function for use cases where default link behavior (opening in the same tab) is preferred.

How to Test:

    Navigate to a page/component that renders Markdown content.
    Verify that links in the markdown content open in new tabs when clicked.
    Ensure that other markdown rendering functionalities remain unaffected.
    Review the TypeScript compilation output to confirm that there are no errors or warnings related to the changes.

Additional Notes:

    This implementation is scoped to affect only markdown-rendered content where the new function is explicitly used. It ensures that the default markdown rendering behavior remains intact for other parts of the application.
    Reviewers are encouraged to focus on the compatibility and potential side effects of these changes on existing markdown content rendering.