### PR TITLE
added checks for JSON.parse to parse only valid JSON objects

### DIFF
--- a/backend/src/contentful/routeHandler.ts
+++ b/backend/src/contentful/routeHandler.ts
@@ -7,7 +7,8 @@ export const routeHandler =
     const variables: TVariables = { ...req.params, ...req.query } as TVariables;
     // check if any of the variables are a stringified JSON object and parse them
     Object.keys(variables).forEach((key) => {
-      if (typeof variables[key] === "string") {
+      const value = variables[key];
+      if (typeof value === "string" && (value.startsWith('{') || value.startsWith('['))) {
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (variables as any)[key] = JSON.parse(variables[key] as string);


### PR DESCRIPTION
This pull request addresses an issue where our server logs were getting overwhelmed with errors from failed attempts to parse strings as JSON. This was not only cluttering our logs, making it hard to spot real issues, but also potentially consuming unnecessary memory. By updating our code to only attempt parsing when a string looks like it could be valid JSON, we reduce the number of errors logged and make our logs cleaner and more useful. This change helps in conserving memory and improving the efficiency of our error logging on EC2.






